### PR TITLE
perf: save opened files for re-access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ test
 #.idea/
 
 .vscode/
+.DS_store

--- a/src/files.rs
+++ b/src/files.rs
@@ -20,6 +20,7 @@ impl WorkingFile {
         let file_path = directory.join(format!("working_file_{id}"));
         let file = Self {
             file: OpenOptions::new()
+                .read(true)
                 .append(true)
                 .create_new(true)
                 .open(&file_path)
@@ -61,5 +62,9 @@ impl WorkingFile {
             .unwrap()
             .to_string_lossy()
             .into_owned();
+    }
+
+    pub fn get_mut_file_ref(&mut self) -> &mut File {
+        return &mut self.file;
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -79,7 +79,7 @@ impl BitcaskHandler {
     /// let value = db.get(b"user:1").unwrap();
     /// println!("Value: {:?}", value);
     /// ```
-    pub fn get(&self, key: &[u8]) -> Result<Vec<u8>, anyhow::Error>{
+    pub fn get(&mut self, key: &[u8]) -> Result<Vec<u8>, anyhow::Error>{
         self.bitcask_engine.get(key)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,14 +4,23 @@ use bitcask::{BitcaskHandler, Options};
 
 
 pub fn main() {
-    let directory_name = Path::new("/Users/seifgneedy/Coding/Rust/bitcask/test");
+    let directory_name = Path::new("test/");
     let mut options = Options::default();
     options.read_write = true;
+    options.max_data_size = 100;
     let mut handler = BitcaskHandler::open(directory_name, Some(options)).unwrap();
-    handler.put("key".as_bytes(), "value".as_bytes()).expect("Error Putting K-V in bitcask");
-    handler.put("key2".as_bytes(), "value2".as_bytes()).expect("Error Putting K-V in bitcask");
+    handler.put("key".as_bytes(), "value32423423423432432423423".as_bytes()).expect("Error Putting K-V in bitcask");
+    handler.put("key2".as_bytes(), "value334253245324324234234234234234324324324lkjsdf3242342sdfsdfsdf3".as_bytes()).expect("Error Putting K-V in bitcask");
+    handler.put("key3".as_bytes(), "value33425324532432423423423423423432432432432423423".as_bytes()).expect("Error Putting K-V in bitcask");
+    handler.put("key3.4".as_bytes(), "value3.4".as_bytes()).expect("Error Putting K-V in bitcask");
     handler.put("key4".as_bytes(), "value4".as_bytes()).expect("Error Putting K-V in bitcask");
-    let val = handler.get(b"key4").unwrap();
+    let val = handler.get(b"key4").unwrap(); // This should get from current working file
     let str_val = String::from_utf8(val).unwrap();
-    println!("Value is {}", str_val);
+    println!("Value4 is {}", str_val);
+    let val = handler.get(b"key3").unwrap(); // This should get from middle working file
+    let str_val = String::from_utf8(val).unwrap();
+    println!("Value3 is {}", str_val);
+    let val = handler.get(b"key").unwrap(); // This should get from first working file
+    let str_val = String::from_utf8(val).unwrap();
+    println!("Value1 is {}", str_val);
 }


### PR DESCRIPTION
Opening files on every `get` call is expensive as it does a system call, switches from user space to kernel, and validates access rights, etc.

For these reasons, we are saving open files in memory for faster access.